### PR TITLE
Fix sentence for using css shorthand

### DIFF
--- a/languages/css.md
+++ b/languages/css.md
@@ -97,7 +97,7 @@ section {
 }
 ```
 
-If you don't need to set all the values, don't use shorthand notation.
+If you don't need to set all the values, use shorthand notation.
 
 Avoid:
 


### PR DESCRIPTION
Straightforward text change, just updates `don't use shorthand notation` to `use shorthand notation` whenever possible.